### PR TITLE
Remove deprecated option from sitemap config

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -96,7 +96,6 @@ export default {
     hostname: 'https://jakubgania.io',
     cacheTime: 1000 * 60 * 15,
     gzip: true,
-    generate: false,
     routes: sitemapRoutes
   },
 


### PR DESCRIPTION
The option `generate: true/false` is deprecated since sitemap-module v1.x 
(see https://github.com/nuxt-community/sitemap-module/blob/9db8e192c2311530d05be05e59e4bf3af41a10e5/lib/options.js#L37)

So you can remove it 😉 